### PR TITLE
MJST-35 get wsl distributions as power shell object array

### DIFF
--- a/wsl-info.ps1
+++ b/wsl-info.ps1
@@ -13,17 +13,20 @@
         As of 2023-02-10, wsl stdout is encoded in 'BigEndianUnicode'.
         Therefor, this function executes wsl commands within modified output encoding.
 #>
-function Invoke-Wsl() {
+function Invoke-UnicodeEncoded() {
     param (
         [scriptblock]
         # Scriptblock to be invoked within changed encoding.
         $scriptBlock
     )
     # temporarily set OutputEncoding
-    $consoleEncoding = ([console]::OutputEncoding)
-    [console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
-    $output = Invoke-Command($scriptBlock)
-    [console]::OutputEncoding = $consoleEncoding
+    $consoleEncoding = [Console]::OutputEncoding
+    [Console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
+    try {
+        $output = Invoke-Command($scriptBlock)
+    } finally {
+        [Console]::OutputEncoding = $consoleEncoding
+    }
     Write-Output $output
 }
 
@@ -35,7 +38,7 @@ function Invoke-Wsl() {
 #>
 function Get-DistributionInfo() {
     # verbose list all installed distributions
-    $content = Invoke-Wsl({ wsl -l -v })
+    $content = Invoke-UnicodeEncoded({ wsl -l -v })
     if ($null -ne $content) {
         $firstLine = $true
         $output = $content | ForEach-Object {

--- a/wsl-info.ps1
+++ b/wsl-info.ps1
@@ -4,30 +4,55 @@
     .DESCRIPTION
         Provides information about wsl instances in format of PowerShell objects.
 #>
-function Get-DistributionInfo() {
-    # verbose list all installed distributions (as of 2023-02-10, this is 'BigEndianUnicode'),
-    #   therefor, replace the BOM
-    $content = (wsl -l -v) -replace '\x00', ''
-    $firstLine = $true
-    $output = $content | ForEach-Object {
-        if ($_.Trim()) {
-            $line = $_ -replace '(\s)+', ','
-            if ($firstLine) {
-                $line = "DEFAULT$line"
-                $firstLine = $false
-            }
-            $line
-        }
-    }
-    Write-Output '--------------'
+
+
+<#
+    .SYNOPSIS
+        Invokes the scriptblock passed.
+    .DESCRIPTION
+        As of 2023-02-10, wsl stdout is encoded in 'BigEndianUnicode'.
+        Therefor, this function executes wsl commands within modified output encoding.
+#>
+function Invoke-Wsl() {
+    param (
+        [scriptblock]
+        # Scriptblock to be invoked within changed encoding.
+        $scriptBlock
+    )
+    # temporarily set OutputEncoding
+    $consoleEncoding = ([console]::OutputEncoding)
+    [console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
+    $output = Invoke-Command($scriptBlock)
+    [console]::OutputEncoding = $consoleEncoding
     Write-Output $output
 }
 
-# MORE SECURE VARIANT!
-# $console = ([console]::OutputEncoding)
-# [console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
-# $distroArray = (wsl -l -v | Select-String <#-SimpleMatch 'Ubuntu'#>) #-split '\s+'
-# [console]::OutputEncoding = $console
-# Write-Output $distroArray
+<#
+    .SYNOPSIS
+        Returns data object containing info about wsl distributions.
+    .DESCRIPTION
+        Table-format: DEFAULT, NAME, STATUS, VERSION;
+#>
+function Get-DistributionInfo() {
+    # verbose list all installed distributions
+    $content = Invoke-Wsl({ wsl -l -v })
+    if ($null -ne $content) {
+        $firstLine = $true
+        $output = $content | ForEach-Object {
+            if ($_.Trim()) {
+                $line = $_ -replace '(\s)+', ',' # replaces multiple spaces by commas
+                if ($firstLine) {
+                    $line = "DEFAULT$line" # append Header for 'DEFAULT'
+                    $firstLine = $false
+                }
+                return $line
+            }
+        }
+        return $output | ConvertFrom-Csv
+    } else {
+        return $null
+    }
+}
 
-Get-DistributionInfo
+$test = Get-DistributionInfo
+Write-Output $test


### PR DESCRIPTION
Correct naming would be: 'object table'.